### PR TITLE
feat: Implement rangefunc support with Listen method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `rpchan` implements some of Go's channels semantics over a TCP connection using `net/rpc`.
 
-It achieves this by providing a very minimal API on the `RPChan` type, exposing 4 methods: `Send`, `Receive`, `Listen` and `Close`. Those four methods are enough to mimic channel semantics.
+It achieves this by providing a very minimal API on the `RPChan` type, exposing 4 methods: `Send`, `Receive`, `Listen` and `Close`. Those four methods are enough to mimic one-way send/receive channel semantics.
 
 It is advisable, but not mandatory, to use the same type on both the receiver and sender. This is because the types follow the [`encoding/gob` guidelines for types and values](https://pkg.go.dev/encoding/gob#hdr-Types_and_Values).
 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@
 It achieves this by providing a very minimal API on the `RPChan` type, exposing only three methods: `Send`, `Receive` and `Close`. Those three methods are enough to mimic channel  semantics.
 
 It is advisable, but not mandatory, to use the same type on both the receiver and sender. This is because the types follow the [`encoding/gob` guidelines for types and values](https://pkg.go.dev/encoding/gob#hdr-Types_and_Values).
+
+If built with `go1.22` and `GOEXPERIMENT=rangefunc`, the `Listen` function can be used on a for-range loop providing the same semantics as a normal Go channel.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 `rpchan` implements some of Go's channels semantics over a TCP connection using `net/rpc`.
 
-It achieves this by providing a very minimal API on the `RPChan` type, exposing only three methods: `Send`, `Receive` and `Close`. Those three methods are enough to mimic channel  semantics.
+It achieves this by providing a very minimal API on the `RPChan` type, exposing 4 methods: `Send`, `Receive`, `Listen` and `Close`. Those four methods are enough to mimic channel semantics.
 
 It is advisable, but not mandatory, to use the same type on both the receiver and sender. This is because the types follow the [`encoding/gob` guidelines for types and values](https://pkg.go.dev/encoding/gob#hdr-Types_and_Values).
 
-If built with `go1.22` and `GOEXPERIMENT=rangefunc`, the `Listen` function can be used on a for-range loop providing the same semantics as a normal Go channel.
+If built with `go1.22` and `GOEXPERIMENT=rangefunc`, the `Listen` method can be used on a for-range loop, working exactly like a Go channel would.

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/lucafmarques/rpchan"
 )
@@ -13,14 +12,12 @@ type T struct {
 }
 
 func main() {
-	ticker := time.NewTicker(time.Millisecond * 100)
 	t := T{
 		A: 1,
 		B: 2,
 		C: "string",
 	}
 	ch := rpchan.New[T](":9091")
-	for range ticker.C {
-		fmt.Println(ch.Send(&t))
-	}
+	fmt.Println(ch.Send(&t))
+	fmt.Println(ch.Close())
 }

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -13,11 +13,7 @@ type T struct {
 
 func main() {
 	ch := rpchan.New[T](":9091", 100)
-	for {
-		v, ok := ch.Receive()
-		fmt.Printf("%+v - %v\n", v, ok)
-		if !ok {
-			return
-		}
+	for v := range ch.Listen() {
+		fmt.Printf("%+v - %v\n", v)
 	}
 }

--- a/internal/receiver.go
+++ b/internal/receiver.go
@@ -22,3 +22,10 @@ func (r *Receiver[T]) Send(item *T, ok *bool) error {
 
 	return err
 }
+
+// Close implements the function signature for an RPC hanlder.
+// It handles a client closing the communication over the rpchan.
+func (r *Receiver[T]) Close(_ int, ok *bool) error {
+	close(r.Channel)
+	return nil
+}

--- a/internal/receiver.go
+++ b/internal/receiver.go
@@ -10,7 +10,7 @@ type Receiver[T any] struct {
 func NewReceiver[T any](buf uint) *Receiver[T] { return &Receiver[T]{make(chan *T, buf)} }
 
 // Send implements the function signature for an RPC handler.
-func (r *Receiver[T]) Send(item *T, ok *bool) error {
+func (r *Receiver[T]) Send(item *T, _ *bool) error {
 	var err error
 	defer func() {
 		recover()
@@ -25,7 +25,7 @@ func (r *Receiver[T]) Send(item *T, ok *bool) error {
 
 // Close implements the function signature for an RPC hanlder.
 // It handles a client closing the communication over the rpchan.
-func (r *Receiver[T]) Close(_ int, ok *bool) error {
+func (r *Receiver[T]) Close(_ int, _ *bool) error {
 	close(r.Channel)
 	return nil
 }

--- a/internal/receiver.go
+++ b/internal/receiver.go
@@ -23,7 +23,7 @@ func (r *Receiver[T]) Send(item *T, _ *bool) error {
 	return err
 }
 
-// Close implements the function signature for an RPC hanlder.
+// Close implements the function signature for an RPC handler.
 // It handles a client closing the communication over the rpchan.
 func (r *Receiver[T]) Close(_ int, _ *bool) error {
 	close(r.Channel)

--- a/rpchan.go
+++ b/rpchan.go
@@ -26,7 +26,7 @@ type RPChan[T any] struct {
 // The first call to Send may panic on dialing the TCP address of the RPChan.
 //
 // Since this involves a network call, Send can return an error.
-func (ch *RPChan[T]) Send(v any) error {
+func (ch *RPChan[T]) Send(v T) error {
 	ch.setupC()
 	return ch.client.Call("Channel.Send", v, nil)
 }

--- a/rpchan.go
+++ b/rpchan.go
@@ -41,7 +41,7 @@ func (ch *RPChan[T]) Receive() (*T, bool) {
 	return v, ok
 }
 
-// Listen implements GOEXPERIMENT=rangefunc iterator semantics
+// Listen implements a GOEXPERIMENT=rangefunc iterator.
 //
 // When used in a for-range loop it works exacly like a Go channel.
 func (ch *RPChan[T]) Listen() func(func(T) bool) {
@@ -74,7 +74,7 @@ func (ch *RPChan[T]) Close() error {
 	return errors.Join(errs...)
 }
 
-// New creates an RPChan[T],  over addr, with an optional N buffer size, and
+// New creates an RPChan[T] over addr, with an optional N buffer size, and
 // returns a reference to it.
 //
 // The returned RPChan[T] will not start a client nor a server unless their

--- a/rpchan.go
+++ b/rpchan.go
@@ -20,7 +20,7 @@ type RPChan[T any] struct {
 	receiver *internal.Receiver[T]
 }
 
-// Send imitates a Go channels' send operation.
+// Send implements Go channels' send operation.
 //
 // A call to Send, much like sending over a Go channel, may block.
 // The first call to Send may panic on dialing the TCP address of the RPChan.
@@ -31,7 +31,7 @@ func (ch *RPChan[T]) Send(v T) error {
 	return ch.client.Call("Channel.Send", v, nil)
 }
 
-// Receive imitates a Go channels' receive operation.
+// Receive implements Go channels' receive operation.
 //
 // A call to Receive, much like receiving over a Go channel, may block.
 // The first call to Receive may panic on listening on the TCP address of RPChan.
@@ -54,7 +54,7 @@ func (ch *RPChan[T]) Listen() func(func(T) bool) {
 	}
 }
 
-// Close imitates a close() call on a normal Go channel.
+// Close implements the close built-in.
 // Since closing involves I/O, it can return an error containing
 // the RPC client's Close() error and/or the TCP listener Close() error.
 func (ch *RPChan[T]) Close() error {
@@ -78,7 +78,7 @@ func (ch *RPChan[T]) Close() error {
 // returns a reference to it.
 //
 // The returned RPChan[T] will not start a client nor a server unless their
-// related methods are called, [RPChan.Send] and [RPChan.Receive], respectively.
+// related methods are called, [RPChan.Send] and [RPChan.Receive] or [RPChan.Listen], respectively.
 func New[T any](addr string, n ...uint) *RPChan[T] {
 	var bufsize uint
 	if len(n) > 0 {


### PR DESCRIPTION
As per [early docs](https://go.dev/wiki/RangefuncExperiment), this PR implements a rangefunc for the `RPChan[T]` type that functions with the same semantics of a for-range loop on a Go channel.